### PR TITLE
Use id instead of report model

### DIFF
--- a/src/services/Export.php
+++ b/src/services/Export.php
@@ -32,7 +32,7 @@ class Export extends Component
     public function csv(\superbig\reports\models\Report $report)
     {
         // @todo Check if successful
-        $result   = Reports::$plugin->getReport()->runReport($report);
+        $result   = Reports::$plugin->getReport()->runReport($report->id);
         $filename = $result->getFilename() . '-' . date('YmdHis') . '.csv';
         $csv      = Writer::createFromString('');
 


### PR DESCRIPTION
Running an export was always selecting the first report instead of the one the export was run from when multiple reports existed. The runReport function expects an id instead of a full report model and doing this locally fixed the issue.